### PR TITLE
Allow runtests caller to specify SORT in environment.

### DIFF
--- a/tests/runtests
+++ b/tests/runtests
@@ -6,12 +6,14 @@
 
 status=0
 
-# We need sort from coreutils for -V
-case `uname -s` in
-	Linux*) SORT=sort ;;
-	Darwin*) SORT=gsort ;;
-	*) SORT=sort ;;
-esac
+if [ -z "${SORT-}" ]; then
+	# We need sort from coreutils for -V
+	case `uname -s` in
+		Linux*) SORT=sort ;;
+		Darwin*) SORT=gsort ;;
+		*) SORT=sort ;;
+	esac
+fi
 
 test_conversion () {
 	test=$1


### PR DESCRIPTION
This makes it easier to script it on platforms like NetBSD which are
not listed in the case, without patching.

Based on a patch applied in pkgsrc, where GNU sort is uniformly called `gsort` on every platform:
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/finance/ledger2beancount/patches/patch-tests_runtests?rev=1.2&content-type=text/x-cvsweb-markup&only_with_tag=MAIN