### PR TITLE
Fix typo in docker command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,7 +64,7 @@ DOCKER_BUILDKIT=1 docker image build -t <IMAGENAME> .
 Now you can run ledger2beancount like this:
 
 ```shell
-docker run --rm v <HOSTDIR>:/usr/ledger2beancount/docker:rw <IMAGENAME> docker/<LEDGER FILE>
+docker run --rm -v <HOSTDIR>:/usr/ledger2beancount/docker:rw <IMAGENAME> docker/<LEDGER FILE>
 ```
 
 ## macOS


### PR DESCRIPTION
The `v` was missing its hyphen. The `:rw` suffix is not needed as that is the default, but it doesn't hurt to have it, so I left it in.

https://docs.docker.com/engine/reference/run/#volume-shared-filesystems